### PR TITLE
WIP: Template to project

### DIFF
--- a/services/web/server/src/simcore_service_webserver/data/fake-template-projects.json
+++ b/services/web/server/src/simcore_service_webserver/data/fake-template-projects.json
@@ -233,7 +233,7 @@
       }
     }
   }, {
-    "projectUuid": "1d4269a4-0fbc-4bf9-9eb3-11356a46c45a",
+    "projectUuid": "DemoDecemberUUID",
     "name": "Demo December",
     "description": "",
     "notes": "",


### PR DESCRIPTION
When starting a project from a template, all the uuids of the services (and connections) need to be recreated. Demo December is the only exception.

Features:
- [ ] Replace templateUUIDs by new ones
- [ ] Make sure Colleen Clancy template use case works
- [ ] "Demo december" is only be listed to admins