### PR TITLE
Re-dispatch filters and actions toolbar

### DIFF
--- a/services/web/client/source/class/osparc/component/export/ExportGroup.js
+++ b/services/web/client/source/class/osparc/component/export/ExportGroup.js
@@ -105,16 +105,18 @@ qx.Class.define("osparc.component.export.ExportGroup", {
         flex: 1
       });
 
-      const exportBtn = new qx.ui.form.Button(this.tr("Export")).set({
-        allowGrowX: false,
-        alignX: "right"
-      });
+      const exportBtn = new qx.ui.toolbar.Button(this.tr("Export"));
       exportBtn.addListener("execute", () => {
         if (manager.validate()) {
           this.__exportAsMacroService(exportBtn);
         }
       }, this);
-      this._add(exportBtn);
+      const actionsBar = new qx.ui.toolbar.ToolBar();
+      const actionsPart = new qx.ui.toolbar.Part();
+      actionsBar.addSpacer();
+      actionsPart.add(exportBtn);
+      actionsBar.add(actionsPart);
+      this._add(actionsBar);
     },
 
     __buildMetaDataForm: function() {

--- a/services/web/client/source/class/osparc/component/filter/UIFilter.js
+++ b/services/web/client/source/class/osparc/component/filter/UIFilter.js
@@ -73,10 +73,6 @@ qx.Class.define("osparc.component.filter.UIFilter", {
         data
       };
       osparc.component.filter.UIFilterController.getInstance().publish(filterData);
-    },
-
-    reapply: function() {
-      osparc.component.filter.UIFilterController.getInstance().dispatch(this.getGroupId());
     }
   }
 });

--- a/services/web/client/source/class/osparc/component/filter/group/ServiceFilterGroup.js
+++ b/services/web/client/source/class/osparc/component/filter/group/ServiceFilterGroup.js
@@ -28,7 +28,7 @@ qx.Class.define("osparc.component.filter.group.ServiceFilterGroup", {
   construct: function(groupId) {
     this.base(arguments);
     this._setLayout(new qx.ui.layout.HBox());
-
+    this.__groupId = groupId;
     const textFilter = this.__textFilter = new osparc.component.filter.TextFilter("text", groupId);
     osparc.utils.Utils.setIdToWidget(textFilter, "serviceFiltersTextFld");
     const tagsFilter = this.__tagsFilter = new osparc.component.filter.NodeTypeFilter("tags", groupId);
@@ -39,6 +39,7 @@ qx.Class.define("osparc.component.filter.group.ServiceFilterGroup", {
   members: {
     __textFilter: null,
     __tagsFilter: null,
+    __groupId: null,
 
     /**
      * Resets the text and active tags.
@@ -49,11 +50,10 @@ qx.Class.define("osparc.component.filter.group.ServiceFilterGroup", {
     },
 
     /**
-     * Resets the text and active tags.
+     * Programmatically triggers filtering again.
      */
-    reapply: function() {
-      this.__textFilter.reapply();
-      this.__tagsFilter.reapply();
+    dispatch: function() {
+      osparc.component.filter.UIFilterController.dispatch(this.__groupId);
     },
 
     /**

--- a/services/web/client/source/class/osparc/desktop/ServiceBrowser.js
+++ b/services/web/client/source/class/osparc/desktop/ServiceBrowser.js
@@ -103,7 +103,7 @@ qx.Class.define("osparc.desktop.ServiceBrowser", {
         })
         .finally(() => {
           this.__reloadBtn.setFetching(false);
-          this.__serviceFilters.reapply();
+          this.__serviceFilters.dispatch();
         });
     },
 


### PR DESCRIPTION
Just moves the triggering of the filters to the filter group and adds a toolbar at the bottom for UI consistency and better visibility of the button.