### PR TITLE
opsie, raising timeout for downloading files to 1 hour

### DIFF
--- a/services/web/server/src/simcore_service_webserver/exporter/file_downloader.py
+++ b/services/web/server/src/simcore_service_webserver/exporter/file_downloader.py
@@ -44,7 +44,7 @@ class ParallelDownloader:
         exporter_settings = get_settings(app)
         results = await wrapped_function(
             timeouts={
-                "total": exporter_settings.max_upload_file_size,
+                "total": exporter_settings.downloader_max_timeout_seconds,
                 "sock_read": 90,  # default as in parfive code
             }
         )


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
fixes an issue with the download timeout set too low

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
