### PR TITLE
reverting export API to use POST requests

### DIFF
--- a/api/specs/webserver/openapi-projects.yaml
+++ b/api/specs/webserver/openapi-projects.yaml
@@ -206,7 +206,7 @@ paths:
         required: false
         schema:
           type: boolean
-    get:
+    post:
       tags:
         - exporter
       summary: creates an archive of the project and downloads it

--- a/services/web/client/source/class/osparc/utils/Utils.js
+++ b/services/web/client/source/class/osparc/utils/Utils.js
@@ -201,7 +201,7 @@ qx.Class.define("osparc.utils.Utils", {
     downloadLink: function(url, fileName, downloadStartedCB) {
       return new Promise((resolve, reject) => {
         let xhr = new XMLHttpRequest();
-        xhr.open("GET", url, true);
+        xhr.open("POST", url, true);
         xhr.responseType = "blob";
         xhr.addEventListener("progress", () => {
           if (xhr.readyState === XMLHttpRequest.LOADING) {

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -10579,7 +10579,7 @@ paths:
         required: false
         schema:
           type: boolean
-    get:
+    post:
       tags:
         - exporter
       summary: creates an archive of the project and downloads it
@@ -12661,6 +12661,11 @@ paths:
                                     description: url of the latest screenshot of the node
                                     example:
                                       - 'https://placeimg.com/171/96/tech/grayscale/?0.jpg'
+                                  runHash:
+                                    description: the hex digest of the resolved inputs +outputs hash at the time when the last outputs were generated
+                                    type: string
+                                    example:
+                                      - a4337bc45a8fc544c03f52dc550cd6e1e87021bc896588bd79e901e2
                                   inputs:
                                     type: object
                                     description: values of input properties

--- a/services/web/server/tests/integration/test_exporter.py
+++ b/services/web/server/tests/integration/test_exporter.py
@@ -317,7 +317,7 @@ async def test_import_export_import(
         project_id=imported_project_uuid
     )
     assert url_export == URL(API_PREFIX + f"/projects/{imported_project_uuid}/export")
-    async with await client.get(url_export, timeout=10) as export_response:
+    async with await client.post(url_export, timeout=10) as export_response:
         assert export_response.status == 200, await export_response.text()
 
         content_disposition_header = export_response.headers["Content-Disposition"]


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
reverting back to POST as the current implementation works regardlessly of POST or GET

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->

https://github.com/ITISFoundation/osparc-simcore/pull/2103
## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
